### PR TITLE
Resolve visual bugs related to Bibliography

### DIFF
--- a/00_main.tex
+++ b/00_main.tex
@@ -319,6 +319,8 @@ Referencing Figure \ref{fig:placeholder} in-text automatically.
 
 \chapter*{Bibliography}
 \addcontentsline{toc}{chapter}{\textcolor{ThemeColor}{Bibliography}} % Add a Bibliography heading to the table of contents
+\fancyhead[LE,LO]{\sffamily\normalsize\thepage} % Header - Odd-Even Page - Left side - show page numbers 
+\fancyhead[RE,RO]{\textbf \bibname} % Header - Odd-Even Page - Right side - show Bibliography text
 
 %------------------------------------------------
 
@@ -326,6 +328,7 @@ Referencing Figure \ref{fig:placeholder} in-text automatically.
 \addcontentsline{toc}{section}{Articles}
 \printbibliography[heading=bibempty,type=article]
 
+\newpage
 %------------------------------------------------
 
 \section*{Books}

--- a/structure.tex
+++ b/structure.tex
@@ -130,12 +130,19 @@
 %	MINI TABLE OF CONTENTS IN PART HEADS
 %----------------------------------------------------------------------------------------
 
+% To override the existing colorred text
+\newcommand{\absolutetextcolor}[2]{%
+    \textcolor{#1}{%
+        \renewcommand\textcolor[2][]{}%
+    #2}%
+}
+
 % Chapter text styling
 \titlecontents{lchapter}
 	[0em] % Left indentation
 	{\addvspace{15pt}\large\sffamily\bfseries} % Spacing and font options for chapters
 	{\color{white}\contentslabel[\Large\thecontentslabel]{1.25cm}\color{white}} % Chapter number
-	{}  
+	{\absolutetextcolor{white}}
 	{\color{white}\normalsize\sffamily\bfseries\;\titlerule*[.5pc]{.}\;\thecontentspage} % Page number
 
 % Section text styling


### PR DESCRIPTION
This PR resolves two visual bugs in Bibliography.

1. Mini TOC in Chapter's cover page. The text `Bibliography` is originally formatted as `ThemeColor`, thus staying hidden under `ThemeColor` background.
![Bib_change](https://github.com/PIX3LFLUX/HSK-Latex-Skript-Template/assets/20220723/0bbc50c6-c6ec-4866-87d1-71c10d91e9d6)

2. Header in Bibliography's pages is affected by previous Chapter (or Kapitel). 
![BibChange2](https://github.com/PIX3LFLUX/HSK-Latex-Skript-Template/assets/20220723/73f37067-e3f5-4d14-8601-8621eb56b120)